### PR TITLE
Dragging fixes

### DIFF
--- a/src/js/leaflet-gesture-handling.js
+++ b/src/js/leaflet-gesture-handling.js
@@ -19,6 +19,7 @@ L.GestureHandler = L.Handler.extend({
 		//Uses native event listeners instead of L.DomEvent due to issues with Android touch events 
 		//turning into pointer events
 		this._map._container.addEventListener("touchstart", this._handleTouch);
+		this._map._container.addEventListener("touchmove", this._handleTouch);
 		this._map._container.addEventListener("touchend", this._handleTouch);
 		this._map._container.addEventListener("click", this._handleTouch);
 
@@ -32,6 +33,7 @@ L.GestureHandler = L.Handler.extend({
         this._enableInteractions();
 
 		this._map._container.removeEventListener("touchstart", this._handleTouch);
+		this._map._container.removeEventListener("touchmove", this._handleTouch);
 		this._map._container.removeEventListener("touchend", this._handleTouch);
 		this._map._container.removeEventListener("click", this._handleTouch);
 
@@ -140,10 +142,15 @@ L.GestureHandler = L.Handler.extend({
 			}
 		}
 
-		if(ignoreElement) {
-			e.target.classList.remove('leaflet-gesture-handling-touch-warning');
-			return;
-		}
+		if (ignoreElement) {
+           if (e.target.classList.contains('leaflet-interactive') && e.type === 'touchmove' && e.touches.length === 1) {
+              this._map._container.classList.add('leaflet-gesture-handling-touch-warning');
+              this._disableInteractions();
+           } else {
+              this._map._container.classList.remove('leaflet-gesture-handling-touch-warning');
+           }
+           return;
+        }
 		// screenLog(e.type+' '+e.touches.length);
 
 		if ( (e.type === 'touchmove' || e.type === 'touchstart' ) && e.touches.length === 1) {

--- a/src/js/leaflet-gesture-handling.js
+++ b/src/js/leaflet-gesture-handling.js
@@ -213,7 +213,9 @@ L.GestureHandler = L.Handler.extend({
 	},
 
 	_handleMouseOut: function (e) {
-		this._disableInteractions();
+		if (!draggingMap) {
+			this._disableInteractions();
+		}
 	}
 
 });

--- a/src/js/leaflet-gesture-handling.js
+++ b/src/js/leaflet-gesture-handling.js
@@ -127,7 +127,10 @@ L.GestureHandler = L.Handler.extend({
 			'leaflet-control-minimap',
 			'leaflet-interactive',
 			'leaflet-popup-content',
-			'leaflet-popup-close-button'
+			'leaflet-popup-content-wrapper',
+			'leaflet-popup-close-button', 
+			'leaflet-control-zoom-in', 
+			'leaflet-control-zoom-out'
 		];
 
 		var ignoreElement = false;

--- a/src/js/leaflet-gesture-handling.js
+++ b/src/js/leaflet-gesture-handling.js
@@ -1,6 +1,6 @@
 /*
 * * Leaflet Gesture Handling **
-* * Version 1.1.2
+* * Version 1.1.2-mod
 */
 
 L.Map.mergeOptions({
@@ -23,8 +23,8 @@ L.GestureHandler = L.Handler.extend({
 		this._map._container.addEventListener("click", this._handleTouch);
 
 		L.DomEvent.on(this._map._container, 'mousewheel', this._handleScroll, this);
-		L.DomEvent.on(this._map._container, 'mouseover', this._handleMouseOver, this);
-		L.DomEvent.on(this._map._container, 'mouseout', this._handleMouseOut, this);
+		L.DomEvent.on(this._map, 'mouseover', this._handleMouseOver, this);
+		L.DomEvent.on(this._map, 'mouseout', this._handleMouseOut, this);
 	},
 
 	removeHooks: function () {
@@ -36,8 +36,8 @@ L.GestureHandler = L.Handler.extend({
 		this._map._container.removeEventListener("click", this._handleTouch);
 
 		L.DomEvent.off(this._map._container, 'mousewheel', this._handleScroll, this);
-		L.DomEvent.off(this._map._container, 'mouseover', this._handleMouseOver, this);
-		L.DomEvent.off(this._map._container, 'mouseout', this._handleMouseOut, this);
+		L.DomEvent.off(this._map, 'mouseover', this._handleMouseOver, this);
+		L.DomEvent.off(this._map, 'mouseout', this._handleMouseOut, this);
     },
     
     _disableInteractions: function() {

--- a/src/js/leaflet-gesture-handling.js
+++ b/src/js/leaflet-gesture-handling.js
@@ -7,6 +7,8 @@ L.Map.mergeOptions({
 	gestureHandlingText: {}
 });
 
+var draggingMap = false;
+
 L.GestureHandler = L.Handler.extend({
 
 	addHooks: function () {
@@ -26,6 +28,11 @@ L.GestureHandler = L.Handler.extend({
 		L.DomEvent.on(this._map._container, 'mousewheel', this._handleScroll, this);
 		L.DomEvent.on(this._map, 'mouseover', this._handleMouseOver, this);
 		L.DomEvent.on(this._map, 'mouseout', this._handleMouseOut, this);
+		
+		// Listen to these events so will not disable dragging if the user moves the mouse out the boundary of the map container whilst actively dragging the map.
+		L.DomEvent.on(this._map, 'movestart', this._handleDragging, this);
+        L.DomEvent.on(this._map, 'move', this._handleDragging, this);
+        L.DomEvent.on(this._map, 'moveend', this._handleDragging, this);
 	},
 
 	removeHooks: function () {
@@ -40,7 +47,20 @@ L.GestureHandler = L.Handler.extend({
 		L.DomEvent.off(this._map._container, 'mousewheel', this._handleScroll, this);
 		L.DomEvent.off(this._map, 'mouseover', this._handleMouseOver, this);
 		L.DomEvent.off(this._map, 'mouseout', this._handleMouseOut, this);
+		
+		L.DomEvent.off(this._map, 'movestart', this._handleDragging, this);
+        L.DomEvent.off(this._map, 'move', this._handleDragging, this);
+        L.DomEvent.off(this._map, 'moveend', this._handleDragging, this);
     },
+	
+	_handleDragging: function (e) {
+         if (e.type == 'movestart' || e.type == 'move') {
+            draggingMap = true;
+         } else if (e.type == 'moveend') {
+            draggingMap = false;
+         }
+      },
+
     
     _disableInteractions: function() {
         this._map.dragging.disable();


### PR DESCRIPTION
I have a couple of fixes here. One is when dragging the map but the mouse moves over a marker or polygon this would trigger the `mouseout` event and disable dragging. I have attached the listener to the `_map` object rather than `_map.container` for `mouseover` and `mouseout` events and this fixes the issue.

Also when dragging the map and the mouse moved out of the boundaries of the map container this would disable dragging rather than the normal leaflet behaviour of continuing to drag the map. I have created a new variable `draggingMap` which listens for the Leaflet events `movestart`, `move`, `moveend` and changes the `draggingMap` variable to true or false. And then have changed the `_handleMouseOut` function to only disable interactions if `!draggingMap`.

Finally I added the zoom controls and another popup class to the ignored elements list so the overlay does not appear when single touching these elements `'leaflet-popup-content-wrapper', 'leaflet-control-zoom-in', 'leaflet-control-zoom-out'`.

PS. This is the first pull request I've ever done on github so hopefully I've done it properly.