### PR TITLE
fix SCRIPT1046 error in IE11

### DIFF
--- a/src/js/leaflet-gesture-handling.js
+++ b/src/js/leaflet-gesture-handling.js
@@ -277,7 +277,7 @@ export var GestureHandling = L.Handler.extend({
         }
     },
 
-    _isScrolling: false
+    //_isScrolling: false
 });
 
 L.Map.addInitHook("addHandler", "gestureHandling", GestureHandling);


### PR DESCRIPTION
duplicate definition of _isScrolling in lines 238 and 280 is triggering a SCRIPT1046 error in IE11 in javascript strict mode