### PR TITLE
prepend handler in front of all the map handlers

### DIFF
--- a/src/js/leaflet-gesture-handling.js
+++ b/src/js/leaflet-gesture-handling.js
@@ -279,6 +279,6 @@ export var GestureHandling = L.Handler.extend({
 
 });
 
-L.Map.addInitHook("addHandler", "gestureHandling", GestureHandling);
+L.Map.addInitHook("addHandler", "gestureHandling", GestureHandling, 0);
 
 export default GestureHandling;


### PR DESCRIPTION
Together with PR https://github.com/Leaflet/Leaflet/pull/6474 , this enables the GestureHandling handler to be processed first and that way, the map may be correctly destroyed. Solves https://github.com/elmarquis/Leaflet.GestureHandling/issues/7