### PR TITLE
Capture _map._container for callback to enable usage in shadow DOM

### DIFF
--- a/src/js/leaflet-gesture-handling.js
+++ b/src/js/leaflet-gesture-handling.js
@@ -251,18 +251,15 @@ export var GestureHandling = L.Handler.extend({
             this._map.scrollWheelZoom.disable();
 
             clearTimeout(this._isScrolling);
+			
+			var container = this._map._container;
 
             // Set a timeout to run after scrolling ends
             this._isScrolling = setTimeout(function() {
                 // Run the callback
-                var warnings = document.getElementsByClassName(
-                    "leaflet-gesture-handling-scroll-warning"
-                );
-                for (var i = 0; i < warnings.length; i++) {
-                    L.DomUtil.removeClass(warnings[i],
-                        "leaflet-gesture-handling-scroll-warning"
-                    );
-                }
+				L.DomUtil.removeClass(container,
+					"leaflet-gesture-handling-scroll-warning"
+				);
             }, this._map.options.gestureHandlingOptions.duration);
         }
     },


### PR DESCRIPTION
Currently the overlay for scrolling does not disappear when the map is placed inside a shadow root. That is the case because document.getElementsByClassName is used, which will not find elements in the shadow DOM. Capturing the container and removing the style class via this captured container resolves this issue.