### PR TITLE
Add methods to README for adding handler to existing map

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ var map = L.map("map", {
 });
 ```
 
+Or you can enable and disable this dynamically on an existing map with `map.gestureHandling.enable()` and `map.gestureHandling.disable()`.
+
 ### Use as a module
 
 If you are using a bundler such as Webpack or Parcel, you can load the library as a module. First install the module with:


### PR DESCRIPTION
from leaflet docs: https://leafletjs.com/examples/extending/extending-3-controls.html

And to help some people who are trying to use the plugin on WordPress:  https://wordpress.org/support/topic/gesture-handling-2/#post-12579628