### PR TITLE
text-align: center

### DIFF
--- a/src/scss/leaflet-gesture-handling.scss
+++ b/src/scss/leaflet-gesture-handling.scss
@@ -16,6 +16,7 @@
         justify-content: center;
         display: flex;
         align-items: center;
+        text-align: center;
         padding: 15px;
         position: absolute;
         top: 0;


### PR DESCRIPTION
When having a slim map the text is left aligned.