### PR TITLE
fix the german text for mac scrolling

### DIFF
--- a/src/js/language-content.js
+++ b/src/js/language-content.js
@@ -54,7 +54,7 @@ export default {
     de: {
         touch: "Verschieben der Karte mit zwei Fingern",
         scroll: "Verwende Strg+Scrollen zum Zoomen der Karte",
-        scrollMac: "\u2318"
+        scrollMac: "Verwende \u2318+Scrollen zum Zoomen der Karte"
     },
     //Greek
     el: {


### PR DESCRIPTION
The german text for scrolling on Mac was only the command symbol.
I updated it to use the same text as the scrolling on other operating systems