### PR TITLE
Add preventDefault() to avoid page scroll while panning

### DIFF
--- a/src/js/leaflet-gesture-handling.js
+++ b/src/js/leaflet-gesture-handling.js
@@ -228,6 +228,7 @@ export var GestureHandling = L.Handler.extend({
             );
             this._disableInteractions();
         } else {
+            e.preventDefault();
             this._enableInteractions();
             L.DomUtil.removeClass(this._map._container, 
                 "leaflet-gesture-handling-touch-warning"


### PR DESCRIPTION
Enabling dragging of a map changes the touch-action CSS property
value to prevent the page from scrolling while you are dragging.

However, when dragging is enabled dynamically inside a touch event
this CSS change doesn't affect the current gesture.

Add e.preventDefault() in the event handler to prevent the page
from scrolling while you're performing a two-finger drag action
on the map.

This addresses issue #65 